### PR TITLE
Include missing dependency

### DIFF
--- a/include/expr.hpp
+++ b/include/expr.hpp
@@ -4,6 +4,7 @@
 #include <ostream>
 #include <istream>
 #include <vector>
+#include <limits>
 
 #include "opcodes.hpp"
 namespace nivalis {


### PR DESCRIPTION
Build will fail without `limits` included.